### PR TITLE
Feat/a1-docling-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ data/empresa/contratos/*
 
 # Editais reais (PDFs pesados)
 data/editais/*.pdf
+outputs/
 
 # Python padrão
 __pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pydantic>=2.5
 pytest>=8.0
 ruff>=0.4
+docling>=2.90.0

--- a/scripts/run_a1_tests.py
+++ b/scripts/run_a1_tests.py
@@ -1,0 +1,40 @@
+from src.pipeline.pipeline import Pipeline
+from src.pipeline.context import PipelineContext
+from src.pipeline.filters.f01_ingestion import IngestionFilter
+import os
+'''
+teste da atividade 1 Squad A, cria a pasta output(já no gitignore) e cria txt dos markdown dos editais pra conferencia de tabelas/estruturas/edge cases
+'''
+
+PDFS = [
+    "data/editais/samples/06_02_2026_T_Energetica_Regulamento.pdf",
+    # "data/editais/samples/Boletim-de-Oportunidades-09-2025.pdf",
+    #"data/editais/samples/Chamada-Publica-03.2025-MCTI embrapii.pdf"
+]
+
+def main():
+    os.makedirs("outputs", exist_ok=True)
+    pipeline = Pipeline([IngestionFilter()])
+
+   
+    for pdf in PDFS:
+        output_file = f"outputs/{os.path.basename(pdf)}.txt"
+
+        context = PipelineContext(pdf_path=pdf)
+        result = pipeline.run(context)
+    
+        with open(output_file, "w", encoding="utf-8") as f:
+            f.write(result.markdown_text)
+
+    '''
+        print(f">> Processando: {pdf}")
+
+        print("\n=== INÍCIO ===\n")
+        print(result.markdown_text[:2000])
+
+        print("\n=== FIM ===\n")
+        print(result.markdown_text[-1000:])
+    '''
+
+if __name__ == "__main__":
+    main()

--- a/src/pipeline/base.py
+++ b/src/pipeline/base.py
@@ -1,9 +1,8 @@
 from abc import ABC, abstractmethod
-
 from src.pipeline.context import PipelineContext
 
 
 class Filter(ABC):
     @abstractmethod
-    def run(self, ctx: PipelineContext) -> PipelineContext:
+    def process(self, ctx: PipelineContext) -> PipelineContext:
         pass

--- a/src/pipeline/base.py
+++ b/src/pipeline/base.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 from src.pipeline.context import PipelineContext
 
-
 class Filter(ABC):
     @abstractmethod
     def process(self, ctx: PipelineContext) -> PipelineContext:

--- a/src/pipeline/filters/f01_ingestion.py
+++ b/src/pipeline/filters/f01_ingestion.py
@@ -1,7 +1,16 @@
+from docling.document_converter import DocumentConverter
 from src.pipeline.base import Filter
 from src.pipeline.context import PipelineContext
 
-
 class IngestionFilter(Filter):
-    def run(self, ctx: PipelineContext) -> PipelineContext:
-        return ctx
+    def __init__(self):
+        self.converter = DocumentConverter()
+
+    def process(self, context: PipelineContext) -> None:
+        if not context.pdf_path:
+            raise ValueError(">> pdf_path não foi fornecido")
+
+        # result = self.converter.convert(context.pdf_path)
+        #markdown = result.document.export_to_markdown() # apenas pra visualização de tabelas/estruturas do pdf
+
+        #context.markdown_text = markdown

--- a/src/pipeline/pipeline.py
+++ b/src/pipeline/pipeline.py
@@ -1,0 +1,18 @@
+from typing import List # tipagem
+from src.pipeline.base import Filter # classe dos filtros
+from src.pipeline.context import PipelineContext # objeto que carrega os dados
+
+'''
+orquestrador do pipeline
+pega um dado(context) e passa por uma sequência de filtros
+'''
+
+class Pipeline:
+    def __init__(self, filters: List[Filter]): # List -> lista de objetos do tipo Filter
+        self.filters = filters # lista de filtros
+
+    def run(self, context: PipelineContext) -> PipelineContext: # recebe e retorna PipelineContext
+        for filter in self.filters:
+            filter.process(context) # filtro processa a entrada
+            
+        return context


### PR DESCRIPTION
## O que esse PR faz?
• Implementação inicial da configuração do pipeline e do filtro f01_ingestion (Pipe and Filters).
• Implementação da configuração do Docling e de um script pra testes no reconhecimento dele para ingestão dos editais.
• Análise dos edge cases dos PDFs

## Tarefa relacionada
A1 #2 

## Checklist
- [x] Código roda sem erros localmente -> *um dos 3 pdfs não roda
- [X] Testes unitários passando
- [x] Sem chaves de API ou senhas no código
- [x] .env.example atualizado se necessário
- [x] Documentação atualizada (se aplicável)

## Como testar
- Desfazer os comentários em filters/f01_ingestion.py e rodar scripts/run_a1_tests.py.
- Inserir os pdfs na pasta data/editais/samples e colocar o path na lista PDFS em scripts/run_a1_tests.py.
- Preferível rodar um por vez, descomente o que vai analisar na lista PDFS.
- Ao rodar será criada uma pasta /outputs com os resultados.

## EDGE CASES - IMPORTANTE
• O Docling foi capaz de extrair estrutura textual dos editais, incluindo seções e tabelas em Markdown. Porém, algumas limitações ocorreram.
• Possível necessidade de etapas adicionais de pós-processamento!

1. Problemas com aspas:
    Ex: “proponente” → ' p roponente'

2. Tabelas com estrutura inconsistente em um dos editais -> duplicação de colunas, repetição de títulos:
 
    <img width="1062" height="744" alt="image" src="https://github.com/user-attachments/assets/ac046e1e-a407-477c-93e5-77a8df38531a" />

3. Um pdf com páginas horizontais, muitas cores/imagens, layout não convencional, gera erro de processamento:

    <img width="564" height="352" alt="image" src="https://github.com/user-attachments/assets/44b7cb85-cfcc-4668-97b5-7f26182349f7" />