### PR TITLE
Feat/a1 docling adjustments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pydantic>=2.5
 pytest>=8.0
 ruff>=0.4
 docling>=2.90.0
+pypdf>=6.10.2

--- a/scripts/run_a1_tests.py
+++ b/scripts/run_a1_tests.py
@@ -9,7 +9,7 @@ teste da atividade 1 Squad A, cria a pasta output(já no gitignore) e cria txt d
 PDFS = [
     "data/editais/samples/06_02_2026_T_Energetica_Regulamento.pdf",
     # "data/editais/samples/Boletim-de-Oportunidades-09-2025.pdf",
-    #"data/editais/samples/Chamada-Publica-03.2025-MCTI embrapii.pdf"
+    # "data/editais/samples/Chamada-Publica-03.2025-MCTI embrapii.pdf"
 ]
 
 def main():
@@ -18,13 +18,18 @@ def main():
 
    
     for pdf in PDFS:
-        output_file = f"outputs/{os.path.basename(pdf)}.txt"
+        print(f"\n>> Processando: {pdf}")
 
         context = PipelineContext(pdf_path=pdf)
         result = pipeline.run(context)
-    
+
+        output_file = f"outputs/{os.path.basename(pdf)}.txt"
+
         with open(output_file, "w", encoding="utf-8") as f:
             f.write(result.markdown_text)
+
+        print(f"Arquivo salvo em: {output_file}")
+        print("Processamento concluído.")
 
     '''
         print(f">> Processando: {pdf}")

--- a/src/pipeline/filters/f01_ingestion.py
+++ b/src/pipeline/filters/f01_ingestion.py
@@ -1,16 +1,123 @@
+from pypdf import PdfReader, PdfWriter
 from docling.document_converter import DocumentConverter
 from src.pipeline.base import Filter
 from src.pipeline.context import PipelineContext
+import os
+
 
 class IngestionFilter(Filter):
+    '''
+    Filter responsável por:
+    1. Receber um PDF
+    2. Processar com Docling
+    4. Exportar para Markdown   
+    5. Realizar limpeza básica do texto
+    6. Salvar no PipelineContext
+    '''
     def __init__(self):
         self.converter = DocumentConverter()
 
     def process(self, context: PipelineContext) -> None:
-        if not context.pdf_path:
-            raise ValueError(">> pdf_path não foi fornecido")
+        pdf_path = context.pdf_path
 
-        # result = self.converter.convert(context.pdf_path)
-        #markdown = result.document.export_to_markdown() # apenas pra visualização de tabelas/estruturas do pdf
+        if not os.path.exists(pdf_path):
+            raise FileNotFoundError(f">> PDF não encontrado: {pdf_path}")
 
-        #context.markdown_text = markdown
+        try:
+            result = self.converter.convert(pdf_path)  # converte em docling
+            markdown = result.document.export_to_markdown()  # exporta em markdown
+            markdown = self.clean_markdown(markdown) # remove colunas repetidas e refina markdown
+
+            context.markdown_text = markdown
+        except Exception as e:
+            print(f"\n>> Erro ao processar PDF {pdf_path}: {e}")
+
+        
+    def clean_markdown(self, text) -> str:
+        '''
+        Limpeza inicial dos principais edge cases encontrados na A1.
+        '''
+
+        text = text.replace("&amp;", "&")
+        text = text.replace("\\_", "_")
+
+        lines = text.splitlines()
+        cleaned_lines = []
+
+        for line in lines:  
+            # verifica se existem barras, linhas, colunas duplicadas    
+            if set(line.replace("|", "").replace("-", "").replace(" ", "")) == set():
+                continue
+            
+            # remover colunas duplicadas
+            if line.strip().startswith("|"):
+                line = self.remove_duplicate_columns(line)
+
+            cleaned_lines.append(line)
+
+        return "\n".join(cleaned_lines)
+    
+    def remove_duplicate_columns(self, row) -> str:
+        '''
+        Remove colunas duplicadas simples em tabelas Markdown.
+
+        Exemplo:
+        | A | A | A | Nota |
+
+        vira:
+        | A | Nota |
+        '''
+
+        # separa a linha usando |, remove espaços estras, ignora valores vazios
+        columns = [col.strip() for col in row.split("|") if col.strip()]
+
+        unique_columns = [] # salva valores unicos 
+
+
+        for column in columns:
+            if column not in unique_columns:
+                unique_columns.append(column)
+
+        # reconstroe a linha da tabela 
+        return "| " + " | ".join(unique_columns) + " |"
+    
+    # caso seja necessário posteriormente, função pra o chunking pdf
+    '''
+    def split_pdf(self, pdf_path) -> list[str]: # vai retornar uma lista de paths para os chunks de pdf
+        ''''''
+        Divide PDFs grandes em blocos menores para evitar:
+        - std::bad_alloc
+        - travamentos com OCR
+        - excesso de memória
+        ''''''
+
+        reader = PdfReader(pdf_path)
+        total_pages = len(reader.pages)
+        chunk_files = []
+
+        if total_pages <= self.chunk_size:  # se o pdf for pequeno/menor que os chunks
+            return [pdf_path] # retorna o pdf
+
+        file_name = os.path.splitext(os.path.basename(pdf_path))[0] # pega o nome do arquivo
+
+        for start in range(0, total_pages, self.chunk_size):  # loop de 0 -> última pagina, pulando o número de paginas do chunk
+            writer = PdfWriter()
+            end = min(start + self.chunk_size, total_pages) # define onde o chunk atual termina
+
+            for page_num in range(start, end):
+                writer.add_page(reader.pages[page_num]) # copia as páginas 
+
+            chunk_path = os.path.join(
+                self.temp_dir,
+                f"{file_name}_chunk_{start + 1}_{end}.pdf" # cria o nome do novo arquivo, indicando as páginas dele
+            )
+
+            with open(chunk_path, "wb") as f:
+                writer.write(f) # salva o novo pdf
+
+            chunk_files.append(chunk_path)
+
+        return chunk_files
+    
+    '''
+    


### PR DESCRIPTION
## O que esse PR faz?
• Implementação da limpeza de markdown no filtro f01_ingestion após a conversão com Docling.
• Remoção de colunas duplicadas/triplicadas em tabelas Markdown geradas pelo Docling.
• Remoção de linhas separadoras desnecessárias como | ----- |.
• Tratamento inicial de caracteres especiais como &amp; → & e \_ → _.
• Ajuste do script run_a1_tests para validar a saída final já com o markdown limpo.

## Tarefa relacionada
A1 #2 

## Checklist
- [X] Código roda sem erros localmente
- [X] Testes unitários passando
- [X] Sem chaves de API ou senhas no código
- [ ] .env.example atualizado se necessário
- [ ] Documentação atualizada (se aplicável)

## Como testar
• Inserir os PDFs na pasta data/editais/samples
• Adicionar os caminhos dos arquivos na lista PDFS em scripts/run_a1_tests.py.
• Preferencialmente rodar um PDF por vez, deixando apenas o edital desejado descomentado.